### PR TITLE
fix spacement when optionBtn gone

### DIFF
--- a/Bagnon/components/frame.lua
+++ b/Bagnon/components/frame.lua
@@ -846,7 +846,11 @@ function Frame:PlaceSortBtn()
 	if self:HasSortBtn() then
 		local toggle = self:GetSortBtn() or self:CreateSortBtn()
 		toggle:ClearAllPoints()
-		toggle:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -58, -8)
+		if self:HasOptionsToggle() then
+			toggle:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -57, -8)
+		else
+			toggle:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -32, -8)
+		end
 		toggle:Show()
 
 		return toggle:GetWidth(), toggle:GetHeight()


### PR DESCRIPTION
![old](https://user-images.githubusercontent.com/38044816/198910362-75063c9f-bd53-46b5-8067-b034a4b54914.png)
When removing the Options button, the SortBtn wouldn't automatically readjust its location.

![new](https://user-images.githubusercontent.com/38044816/198910393-b8323ad7-eed3-41f6-89b7-7a9188798c99.png)
Now, if the player opts out to not use the Settings Button, it'll automatically move just like the left side of the bar.