### PR TITLE
feat: changed TOPLEVEL to DIALOG frame strata

### DIFF
--- a/Bagnon/components/frame.lua
+++ b/Bagnon/components/frame.lua
@@ -390,7 +390,7 @@ function Frame:SetFrameLayer(layer)
 	local strata, topLevel = nil, false
 
 	if layer == 'TOPLEVEL' then
-		strata = 'HIGH'
+		strata = 'DIALOG'
 		topLevel = true
 	elseif layer == 'MEDIUMLOW' then
 		strata = 'LOW'


### PR DESCRIPTION
This was made because someone was looking for and not only that but within Bagnon when changing the frame layer there's "HIGH" and "TOPLEVEL", and both of them were doing the same thing