### PR TITLE
fix(db): :bug: Fixes an issue where personal and realm bank information wouldn't get updated

### DIFF
--- a/Bagnon/components/sortBtn.lua
+++ b/Bagnon/components/sortBtn.lua
@@ -23,6 +23,9 @@ local function GetIDFromLink(link)
 end
 
 local function GetAscensionBankType()
+	-- The logic doesn't work because GuildBankFrame is not loaded
+	-- However the sort still works because it can sort using 'guild' as a fallback
+	-- but personal and realm branches are never reached
 	if GuildBankFrame and GuildBankFrame.IsPersonalBank then
 		return "personal"
 	elseif GuildBankFrame and GuildBankFrame.IsRealmBank then

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -15,6 +15,7 @@ BagnonDB:RegisterEvent('ADDON_LOADED')
 
 ASC_PERSONAL_BANK_OFFSET = 1000;
 ASC_REALM_BANK_OFFSET = 2000;
+GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET = 2;  -- Offset used to identify when guild bank tabs are loaded
 
 --constants
 local L = BAGNON_FOREVER_LOCALS
@@ -146,6 +147,7 @@ function BagnonDB:PLAYER_LOGIN()
 
 	self:RegisterEvent('GUILDBANKFRAME_OPENED')
 	self:RegisterEvent('GUILDBANKBAGSLOTS_CHANGED')
+	self:RegisterEvent('GUILDBANKFRAME_CLOSED')
 	self:RegisterEvent('BANKFRAME_OPENED')
 	self:RegisterEvent('BANKFRAME_CLOSED')
 	self:RegisterEvent('PLAYER_MONEY')
@@ -191,6 +193,7 @@ end
 
 
 function BagnonDB:GUILDBANKFRAME_OPENED()
+	-- Identify bank type from permissions payload
 	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
 		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
 		if json then
@@ -202,47 +205,67 @@ function BagnonDB:GUILDBANKFRAME_OPENED()
 		end
 	end
 
-	if self.IsPersonalBank then
-		for i = 1, 6 do
-			local avail = GetGuildBankTabInfo(i)
-			if type(avail) == "string" then
-				self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
-			end
+	self.guildBankUpdateCalls = 0
+	self.availableTabs = {} -- table of available tabs
+
+	-- Query all tabs for personal and realm bank to preload data
+	for i = 1, 6 do
+		local avail = GetGuildBankTabInfo(i)
+		if type(avail) == "string" and i ~= currentTab then
+			QueryGuildBankTab(i)
+			self.availableTabs[i] = avail
 		end
-		return
 	end
 
-	if self.IsRealmBank then
-		for i = 1, 6 do
-			local avail = GetGuildBankTabInfo(i)
-			if type(avail) == "string" then
-				self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
-			end
-		end
-	end
+
 end
+
 
 function BagnonDB:GUILDBANKBAGSLOTS_CHANGED()
-	if self.IsPersonalBank then
-		for i = 1, 6 do
-			local avail = GetGuildBankTabInfo(i)
-			if type(avail) == "string" then
+	self.guildBankUpdateCalls = self.guildBankUpdateCalls + 1
+	local currentTab = GetCurrentGuildBankTab()
+
+	-- Special operation: After 2 initial calls, the QueryGuildBankTab calls above
+	-- trigger the GUILDBANKBAGSLOTS_CHANGED event  at which the queried items are available.
+
+	-- Only update the bank if we are within 1-6 range of the initial calls as those
+	-- are likely triggered by the QueryGuildBankTab calls above. Which makes items
+	-- in the tabs available for GetGuildBankItemInfo calls.
+	if ((self.guildBankUpdateCalls > GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET)
+		and (self.guildBankUpdateCalls <= GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET + #self.availableTabs)) then
+		for i, avail in pairs(self.availableTabs) do
+			-- Ignore current tab, and only update the tab that is next in the sequence
+			if (i ~= currentTab and self.guildBankUpdateCalls == GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET + i) then
 				self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
 			end
 		end
 		return
 	end
 
-	if self.IsRealmBank then
-		for i = 1, 6 do
-			local avail = GetGuildBankTabInfo(i)
-			if type(avail) == "string" then
-				self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
-			end
+	-- Normal operation: Update current tab
+	if self.IsPersonalBank then
+		local avail = GetGuildBankTabInfo(currentTab)
+		if type(avail) == "string" then
+			self:UpdateBag(currentTab + ASC_PERSONAL_BANK_OFFSET)
 		end
+		return
+	end
+
+	-- Update all tabs for realm bank on any change
+	if self.IsRealmBank then
+		local avail = GetGuildBankTabInfo(currentTab)
+		if type(avail) == "string" then
+			self:UpdateBag(currentTab + ASC_REALM_BANK_OFFSET)
+		end
+		return
 	end
 end
 
+function BagnonDB:GUILDBANKFRAME_CLOSED()
+	self.IsPersonalBank = nil
+	self.IsRealmBank = nil
+	self.guildBankUpdateCalls = 0
+end
 
 function BagnonDB:UNIT_INVENTORY_CHANGED(event, unit)
 	if unit == 'player' then

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -13,10 +13,8 @@ BagnonDB:SetScript('OnEvent', function(self, event, arg1)
 end)
 BagnonDB:RegisterEvent('ADDON_LOADED')
 
-
 ASC_PERSONAL_BANK_OFFSET = 1000;
 ASC_REALM_BANK_OFFSET = 2000;
-
 
 --constants
 local L = BAGNON_FOREVER_LOCALS
@@ -30,13 +28,6 @@ local playerList --a sorted list of players
 
 
 --[[ Local Functions ]]--
-local function IsPersonalBank()
-	return GuildBankFrame and GuildBankFrame.IsPersonalBank
-end
-
-local function IsRealmBank()
-	return GuildBankFrame and GuildBankFrame.IsRealmBank
-end
 
 local function ToIndex(bag, slot)
 	if tonumber(bag) then
@@ -47,17 +38,6 @@ end
 
 local function ToBagIndex(bag)
 	return (tonumber(bag) and bag*100) or bag
-end
-
-local function HideBlizzardGuildBankFrame()
-	-- Move frame off-screen
-	-- Reasoning: If we call :Hide() the Bagnon UI also hides
-	-- TODO: We have to find a cleaner way to hide the Blizzard guild bank UI
-
-	if GuildBankFrame then
-		GuildBankFrame:SetClampedToScreen(false)
-		GuildBankFrame:SetPoint("TOPLEFT", UIParent, "TOPLEFT", -1e5, 1e5)
-	end
 end
 
 --returns the full item link only for items that have enchants/suffixes, otherwise returns the item's ID
@@ -95,8 +75,6 @@ end
 
 function BagnonDB:Initialize()
 	self:LoadSettings()
-
-	LoadAddOn('Blizzard_GuildBankUI')
 
 	self:SetScript('OnEvent', function(self, event, ...)
 		if self[event] then
@@ -165,6 +143,7 @@ function BagnonDB:PLAYER_LOGIN()
 	self:SaveEquipment()
 	self:SaveNumBankSlots()
 
+
 	self:RegisterEvent('GUILDBANKFRAME_OPENED')
 	self:RegisterEvent('GUILDBANKBAGSLOTS_CHANGED')
 	self:RegisterEvent('BANKFRAME_OPENED')
@@ -212,9 +191,18 @@ end
 
 
 function BagnonDB:GUILDBANKFRAME_OPENED()
-	HideBlizzardGuildBankFrame()
+	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
+		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
+		if json then
+			local jsonObject = C_Serialize:FromJSON(json)
+			if jsonObject then
+				self.IsPersonalBank = jsonObject.IsPersonalBank
+				self.IsRealmBank = jsonObject.IsRealmBank
+			end
+		end
+	end
 
-	if IsPersonalBank() then
+	if self.IsPersonalBank then
 		for i = 1, 6 do
 			local avail = GetGuildBankTabInfo(i)
 			if type(avail) == "string" then
@@ -224,7 +212,7 @@ function BagnonDB:GUILDBANKFRAME_OPENED()
 		return
 	end
 
-	if IsRealmBank() then
+	if self.IsRealmBank then
 		for i = 1, 6 do
 			local avail = GetGuildBankTabInfo(i)
 			if type(avail) == "string" then

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -236,7 +236,13 @@ function BagnonDB:GUILDBANKBAGSLOTS_CHANGED()
 		for i, avail in pairs(self.availableTabs) do
 			-- Ignore current tab, and only update the tab that is next in the sequence
 			if (i ~= currentTab and self.guildBankUpdateCalls == GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET + i) then
-				self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
+				if self.IsPersonalBank then
+					self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
+				elseif self.IsRealmBank then
+					self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
+				else
+					print("[BagnonForever] Error: Unknown bank type")
+				end
 			end
 		end
 		return

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -223,7 +223,7 @@ function BagnonDB:GUILDBANKFRAME_OPENED()
 end
 
 function BagnonDB:GUILDBANKBAGSLOTS_CHANGED()
-	if IsPersonalBank() then
+	if self.IsPersonalBank then
 		for i = 1, 6 do
 			local avail = GetGuildBankTabInfo(i)
 			if type(avail) == "string" then
@@ -233,7 +233,7 @@ function BagnonDB:GUILDBANKBAGSLOTS_CHANGED()
 		return
 	end
 
-	if IsRealmBank() then
+	if self.IsRealmBank then
 		for i = 1, 6 do
 			local avail = GetGuildBankTabInfo(i)
 			if type(avail) == "string" then

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -13,16 +13,10 @@ BagnonDB:SetScript('OnEvent', function(self, event, arg1)
 end)
 BagnonDB:RegisterEvent('ADDON_LOADED')
 
+
 ASC_PERSONAL_BANK_OFFSET = 1000;
 ASC_REALM_BANK_OFFSET = 2000;
 
-local function IsPersonalBank()
-	return GuildBankFrame and GuildBankFrame.IsPersonalBank
-end
-
-local function IsRealmBank()
-	return GuildBankFrame and GuildBankFrame.IsRealmBank
-end
 
 --constants
 local L = BAGNON_FOREVER_LOCALS
@@ -36,6 +30,13 @@ local playerList --a sorted list of players
 
 
 --[[ Local Functions ]]--
+local function IsPersonalBank()
+	return GuildBankFrame and GuildBankFrame.IsPersonalBank
+end
+
+local function IsRealmBank()
+	return GuildBankFrame and GuildBankFrame.IsRealmBank
+end
 
 local function ToIndex(bag, slot)
 	if tonumber(bag) then
@@ -48,14 +49,25 @@ local function ToBagIndex(bag)
 	return (tonumber(bag) and bag*100) or bag
 end
 
+local function HideBlizzardGuildBankFrame()
+	-- Move frame off-screen
+	-- Reasoning: If we call :Hide() the Bagnon UI also hides
+	-- TODO: We have to find a cleaner way to hide the Blizzard guild bank UI
+
+	if GuildBankFrame then
+		GuildBankFrame:SetClampedToScreen(false)
+		GuildBankFrame:SetPoint("TOPLEFT", UIParent, "TOPLEFT", -1e5, 1e5)
+	end
+end
+
 --returns the full item link only for items that have enchants/suffixes, otherwise returns the item's ID
 local function ToShortLink(link)
 	if link then
 		local a,b,c,d,e,f,g,h = link:match('(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+)')
-		
+
 		--ASC sets this to unique id in the personal bank, clear it
 		c = 0;
-		
+
 		if(b == '0' and b == c and c == d and d == e and e == f and f == g) then
 			return a
 		end
@@ -67,11 +79,11 @@ local function GetBagSize(bag)
 	if bag == KEYRING_CONTAINER then
 		return GetKeyRingSize()
 	end
-	
+
 	if (bag >= ASC_PERSONAL_BANK_OFFSET) then
 		return 98
 	end
-		
+
 	if bag == 'e' then
 		return NUM_EQUIPMENT_SLOTS
 	end
@@ -83,6 +95,8 @@ end
 
 function BagnonDB:Initialize()
 	self:LoadSettings()
+
+	LoadAddOn('Blizzard_GuildBankUI')
 
 	self:SetScript('OnEvent', function(self, event, ...)
 		if self[event] then
@@ -151,7 +165,6 @@ function BagnonDB:PLAYER_LOGIN()
 	self:SaveEquipment()
 	self:SaveNumBankSlots()
 
-
 	self:RegisterEvent('GUILDBANKFRAME_OPENED')
 	self:RegisterEvent('GUILDBANKBAGSLOTS_CHANGED')
 	self:RegisterEvent('BANKFRAME_OPENED')
@@ -199,6 +212,8 @@ end
 
 
 function BagnonDB:GUILDBANKFRAME_OPENED()
+	HideBlizzardGuildBankFrame()
+
 	if IsPersonalBank() then
 		for i = 1, 6 do
 			local avail = GetGuildBankTabInfo(i)
@@ -391,11 +406,11 @@ function BagnonDB:GetItemCount(itemLink, bag, player)
 	local total = 0
 	local itemLink = select(2, GetItemInfo(ToShortLink(itemLink)))
 	local size = (self:GetBagData(bag, player)) or 0
-	
+
 	if (bag == "e") then
 		size = NUM_EQUIPMENT_SLOTS
 	end
-	
+
 	for slot = 1, size do
 		local link, count = self:GetItemData(bag, slot, player)
 		if link == itemLink then
@@ -432,7 +447,7 @@ function BagnonDB:SaveEquipment()
 			local link = ToShortLink(link)
 			local count =  GetInventoryItemCount('player', slot)
 			count = count > 1 and count or nil
-			
+
 			if(link and count) then
 				self.pdb[index] = format('%s,%d', link, count)
 			else
@@ -513,7 +528,7 @@ function BagnonDB:SaveBag(bag)
 		local size =  GetBagSize(bag)
 		local index = ToBagIndex(bag)
 		self.pdb[index] = size
-	else 
+	else
 		local size = GetBagSize(bag)
 		local index = ToBagIndex(bag)
 
@@ -535,11 +550,11 @@ function BagnonDB:SaveBag(bag)
 		else
 			self.pdb[index] = nil
 		end
-		
-		
+
+
 	end
-	
-	
+
+
 
 end
 


### PR DESCRIPTION
~~Introduce the "Blizzard_GuildBankUI" addon in constructor, ensuring that the `GuildBankFrame` is loaded for bank type detection.~~

~~I'm no expert in LUA or Wow addons for that matter, so this implementation has some caveats that need to be fixed:~~
~~- Hides the Blizzard Guildbank by moving it out of frame to avoid both Bagnon and Blizzard banks being shown at the same time.~~
~~- Breaks the red color from the bank tabs as the `isViewable` var is `true` for all bank tabs in https://github.com/Ascension-Addons/Bagnon/blob/main/Bagnon_GuildBank/components/tab.lua#L166-L178~~

Reintroduce the old implementation of personal and realm bank detection and fix a bug where only currently opened tab would be added to db