### PR TITLE
Better Realm/Personal bank detection

### DIFF
--- a/Bagnon/main.lua
+++ b/Bagnon/main.lua
@@ -332,10 +332,6 @@ function Bagnon:GUILDBANKFRAME_OPENED()
 		GuildBankFrame = CreateFrame("Frame", "GuildBankFrame")
 	end
 	-- Detect bank type from first tab name
-	local numTabs = GetNumGuildBankTabs()
-	local firstTabName = numTabs > 0 and GetGuildBankTabInfo(1) or nil
-	GuildBankFrame.IsPersonalBank = (firstTabName == "Personal Bank")
-	GuildBankFrame.IsRealmBank = (firstTabName == "Realm Bank")
 	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
 		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
 		if json then

--- a/Bagnon/main.lua
+++ b/Bagnon/main.lua
@@ -331,7 +331,7 @@ function Bagnon:GUILDBANKFRAME_OPENED()
 	if not GuildBankFrame then
 		GuildBankFrame = CreateFrame("Frame", "GuildBankFrame")
 	end
-	-- Detect bank type from first tab name
+	-- Detect bank type
 	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
 		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
 		if json then

--- a/Bagnon/main.lua
+++ b/Bagnon/main.lua
@@ -327,6 +327,26 @@ end
 
 --visiting the guild bank
 function Bagnon:GUILDBANKFRAME_OPENED()
+	-- Ascension: Create GuildBankFrame with bank type properties for addon compatibility
+	if not GuildBankFrame then
+		GuildBankFrame = CreateFrame("Frame", "GuildBankFrame")
+	end
+	-- Detect bank type from first tab name
+	local numTabs = GetNumGuildBankTabs()
+	local firstTabName = numTabs > 0 and GetGuildBankTabInfo(1) or nil
+	GuildBankFrame.IsPersonalBank = (firstTabName == "Personal Bank")
+	GuildBankFrame.IsRealmBank = (firstTabName == "Realm Bank")
+	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
+		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
+		if json then
+			local jsonObject = C_Serialize:FromJSON(json)
+			if jsonObject then
+				GuildBankFrame.IsPersonalBank = jsonObject.IsPersonalBank
+				GuildBankFrame.IsRealmBank = jsonObject.IsRealmBank
+			end
+		end
+	end
+
 	self:ShowFrameAtEvent('inventory', 'guildbank')
 end
 

--- a/Bagnon_Forever/db.lua
+++ b/Bagnon_Forever/db.lua
@@ -15,7 +15,14 @@ BagnonDB:RegisterEvent('ADDON_LOADED')
 
 ASC_PERSONAL_BANK_OFFSET = 1000;
 ASC_REALM_BANK_OFFSET = 2000;
-GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET = 2;  -- Offset used to identify when guild bank tabs are loaded
+
+local function IsPersonalBank()
+	return GuildBankFrame and GuildBankFrame.IsPersonalBank
+end
+
+local function IsRealmBank()
+	return GuildBankFrame and GuildBankFrame.IsRealmBank
+end
 
 --constants
 local L = BAGNON_FOREVER_LOCALS
@@ -45,10 +52,10 @@ end
 local function ToShortLink(link)
 	if link then
 		local a,b,c,d,e,f,g,h = link:match('(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+)')
-
+		
 		--ASC sets this to unique id in the personal bank, clear it
 		c = 0;
-
+		
 		if(b == '0' and b == c and c == d and d == e and e == f and f == g) then
 			return a
 		end
@@ -60,11 +67,11 @@ local function GetBagSize(bag)
 	if bag == KEYRING_CONTAINER then
 		return GetKeyRingSize()
 	end
-
+	
 	if (bag >= ASC_PERSONAL_BANK_OFFSET) then
 		return 98
 	end
-
+		
 	if bag == 'e' then
 		return NUM_EQUIPMENT_SLOTS
 	end
@@ -147,7 +154,6 @@ function BagnonDB:PLAYER_LOGIN()
 
 	self:RegisterEvent('GUILDBANKFRAME_OPENED')
 	self:RegisterEvent('GUILDBANKBAGSLOTS_CHANGED')
-	self:RegisterEvent('GUILDBANKFRAME_CLOSED')
 	self:RegisterEvent('BANKFRAME_OPENED')
 	self:RegisterEvent('BANKFRAME_CLOSED')
 	self:RegisterEvent('PLAYER_MONEY')
@@ -193,85 +199,47 @@ end
 
 
 function BagnonDB:GUILDBANKFRAME_OPENED()
-	-- Identify bank type from permissions payload
-	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
-		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
-		if json then
-			local jsonObject = C_Serialize:FromJSON(json)
-			if jsonObject then
-				self.IsPersonalBank = jsonObject.IsPersonalBank
-				self.IsRealmBank = jsonObject.IsRealmBank
+	if IsPersonalBank() then
+		for i = 1, 6 do
+			local avail = GetGuildBankTabInfo(i)
+			if type(avail) == "string" then
+				self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
+			end
+		end
+		return
+	end
+
+	if IsRealmBank() then
+		for i = 1, 6 do
+			local avail = GetGuildBankTabInfo(i)
+			if type(avail) == "string" then
+				self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
 			end
 		end
 	end
-
-	self.guildBankUpdateCalls = 0
-	self.availableTabs = {} -- table of available tabs
-
-	-- Query all tabs for personal and realm bank to preload data
-	for i = 1, 6 do
-		local avail = GetGuildBankTabInfo(i)
-		if type(avail) == "string" and i ~= currentTab then
-			QueryGuildBankTab(i)
-			self.availableTabs[i] = avail
-		end
-	end
-
-
 end
-
 
 function BagnonDB:GUILDBANKBAGSLOTS_CHANGED()
-	self.guildBankUpdateCalls = self.guildBankUpdateCalls + 1
-	local currentTab = GetCurrentGuildBankTab()
-
-	-- Special operation: After 2 initial calls, the QueryGuildBankTab calls above
-	-- trigger the GUILDBANKBAGSLOTS_CHANGED event  at which the queried items are available.
-
-	-- Only update the bank if we are within 1-6 range of the initial calls as those
-	-- are likely triggered by the QueryGuildBankTab calls above. Which makes items
-	-- in the tabs available for GetGuildBankItemInfo calls.
-	if ((self.guildBankUpdateCalls > GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET)
-		and (self.guildBankUpdateCalls <= GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET + #self.availableTabs)) then
-		for i, avail in pairs(self.availableTabs) do
-			-- Ignore current tab, and only update the tab that is next in the sequence
-			if (i ~= currentTab and self.guildBankUpdateCalls == GUILDBANKBAGSLOTS_CHANGED_INIT_OFFSET + i) then
-				if self.IsPersonalBank then
-					self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
-				elseif self.IsRealmBank then
-					self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
-				else
-					print("[BagnonForever] Error: Unknown bank type")
-				end
+	if IsPersonalBank() then
+		for i = 1, 6 do
+			local avail = GetGuildBankTabInfo(i)
+			if type(avail) == "string" then
+				self:UpdateBag(i + ASC_PERSONAL_BANK_OFFSET)
 			end
 		end
 		return
 	end
 
-	-- Normal operation: Update current tab
-	if self.IsPersonalBank then
-		local avail = GetGuildBankTabInfo(currentTab)
-		if type(avail) == "string" then
-			self:UpdateBag(currentTab + ASC_PERSONAL_BANK_OFFSET)
+	if IsRealmBank() then
+		for i = 1, 6 do
+			local avail = GetGuildBankTabInfo(i)
+			if type(avail) == "string" then
+				self:UpdateBag(i + ASC_REALM_BANK_OFFSET)
+			end
 		end
-		return
-	end
-
-	-- Update all tabs for realm bank on any change
-	if self.IsRealmBank then
-		local avail = GetGuildBankTabInfo(currentTab)
-		if type(avail) == "string" then
-			self:UpdateBag(currentTab + ASC_REALM_BANK_OFFSET)
-		end
-		return
 	end
 end
 
-function BagnonDB:GUILDBANKFRAME_CLOSED()
-	self.IsPersonalBank = nil
-	self.IsRealmBank = nil
-	self.guildBankUpdateCalls = 0
-end
 
 function BagnonDB:UNIT_INVENTORY_CHANGED(event, unit)
 	if unit == 'player' then
@@ -423,11 +391,11 @@ function BagnonDB:GetItemCount(itemLink, bag, player)
 	local total = 0
 	local itemLink = select(2, GetItemInfo(ToShortLink(itemLink)))
 	local size = (self:GetBagData(bag, player)) or 0
-
+	
 	if (bag == "e") then
 		size = NUM_EQUIPMENT_SLOTS
 	end
-
+	
 	for slot = 1, size do
 		local link, count = self:GetItemData(bag, slot, player)
 		if link == itemLink then
@@ -464,7 +432,7 @@ function BagnonDB:SaveEquipment()
 			local link = ToShortLink(link)
 			local count =  GetInventoryItemCount('player', slot)
 			count = count > 1 and count or nil
-
+			
 			if(link and count) then
 				self.pdb[index] = format('%s,%d', link, count)
 			else
@@ -545,7 +513,7 @@ function BagnonDB:SaveBag(bag)
 		local size =  GetBagSize(bag)
 		local index = ToBagIndex(bag)
 		self.pdb[index] = size
-	else
+	else 
 		local size = GetBagSize(bag)
 		local index = ToBagIndex(bag)
 
@@ -567,11 +535,11 @@ function BagnonDB:SaveBag(bag)
 		else
 			self.pdb[index] = nil
 		end
-
-
+		
+		
 	end
-
-
+	
+	
 
 end
 


### PR DESCRIPTION
This is a cleaner way of detecting whereas a bank is Personal, Guild or Realm.
We also create a Mock GuildBankFrame of the base Ascension API in case other addons uses it to detect bank types.

maybe related PR that uses the same pattern:
https://github.com/Ascension-Addons/TradeSkillMaster/pull/29